### PR TITLE
fixes capitalization and small grammar errors

### DIFF
--- a/learns-app-content/week-01/discussions.md
+++ b/learns-app-content/week-01/discussions.md
@@ -66,7 +66,7 @@ The scaffolded project includes a starter SPA and a few supporting files. None o
 ├── .git/...
 ├── .gitignore
 ├── README.md
-├── ESLint.config.js
+├── eslint.config.js
 ├── index.html
 ├── package.json
 ├── node_modules/...
@@ -83,10 +83,10 @@ The scaffolded project includes a starter SPA and a few supporting files. None o
 
 ```
 
-1. **.git/**: is an invisible directory created by git to maintain version control. You may not see it if your operating system hides directories and files that start with a ".". VS Code also will hide this directory by default.
+1. **.git/**: is an invisible directory created by Git to maintain version control. You may not see it if your operating system hides directories and files that start with a ".". VS Code also will hide this directory by default.
 2. **.gitignore**: this file lists all those files and directories that should _not_ be tracked with version control.
 3. **README.md**: this file contains pertinent information about the project. We keep this up to date with details such as a project description and steps that others need to take to run or work with the project.
-4. **ESLint.config.js**: is used to configure [ESLint](https://ESLint.org/), a tool used to identify syntax problems or common [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern).
+4. **eslint.config.js**: is used to configure [ESLint](https://eslint.org/), a tool used to identify syntax problems or common [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern).
 5. **index.html**: this file is the [entry point](https://vitejs.dev/guide/#index-html-and-project-root) for the application.
 6. **package.json**: this file contains details about the project, some scripts aliases, and a list of all the packages that the project is dependent upon.
 7. **public**: this is a [directory](https://vitejs.dev/guide/assets.html#the-public-directory) is used to hold static assets like images and fonts that we want to remain unchanged.
@@ -99,7 +99,7 @@ To work with the project, we have to start Vite's server. To find the right comm
 "scripts": {
   "dev": "vite",
   "build": "vite build",
-  "lint": "ESLint .",
+  "lint": "eslint .",
   "preview": "vite preview"
 }
 ```

--- a/learns-app-content/week-01/references.md
+++ b/learns-app-content/week-01/references.md
@@ -29,7 +29,7 @@
 
 ## Improving the Development Environment
 
-- [ESLint Core Concepts (ESLint docs)](https://ESLint.org/docs/latest/use/core-concepts/)
+- [ESLint Core Concepts (ESLint docs)](https://eslint.org/docs/latest/use/core-concepts/)
 - [VS CODE ESLint Extension (VS Marketplace)](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [Prettier (Prettier docs)](https://prettier.io/docs/en/)
 - [Prettier Formatter for Visual Studio Code (VS Marketplace)](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)

--- a/supplementals/eslint/eslint.md
+++ b/supplementals/eslint/eslint.md
@@ -1,6 +1,6 @@
 # Enhance VS Code's Built-in Linting with ESLint
 
-A linter is a tool that performs a [static analysis](https://en.wikipedia.org/wiki/Static_program_analysis)of a codebase to flag syntax errors and bad practices without having to run the code. VS Code already provides basic static analysis for JavaScript but we can extend this with ESLint. The React template includes some sensible default rules when we installed it but we also have to install VS Code's [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension. The extension will allow VS Code to lint all project files and adds a tooltip when mousing over a flagged item. The tooltips usually include a brief summary of the rule violation and a link to more documentation. In the screenshot below, clicking the blue text "[react/jsx-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)" will open a browser window to documentation that explains the error, how to resolve it, and even rule configuration options for `eslint.config.js`.
+A linter is a tool that performs a [static analysis](https://en.wikipedia.org/wiki/Static_program_analysis) of a codebase to flag syntax errors and bad practices without having to run the code. VS Code already provides basic static analysis for JavaScript but we can extend this with ESLint. The React template includes some sensible default rules when we installed it but we also have to install VS Code's [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension. The extension will allow VS Code to lint all project files and adds a tooltip when mousing over a flagged item. The tooltips usually include a brief summary of the rule violation and a link to more documentation. In the screenshot below, clicking the blue text "[react/jsx-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)" will open a browser window to documentation that explains the error, how to resolve it, and even rule configuration options for `eslint.config.js`.
 
 ![missing key props error in ide](https://raw.githubusercontent.com/Code-the-Dream-School/react-curriculum-v4/refs/heads/main/supplementals/eslint/assets/missing-key.png)
 
@@ -11,7 +11,7 @@ In the following screenshot of an error tooltip, we have an error on `setTestLis
 
 ![no unused vars tooltip](https://raw.githubusercontent.com/Code-the-Dream-School/react-curriculum-v4/refs/heads/main/supplementals/eslint/assets/unused-vars.png)
 
-When working with ESLint, we can to add and remove rules that suit our needs. ESLint provides three ways to modify rules:
+When working with ESLint, we can add and remove rules that suit our needs. ESLint provides three ways to modify rules:
 
 1. ignore a rule for a file
 2. ignore a rule for a single line

--- a/supplementals/prettier/prettier.md
+++ b/supplementals/prettier/prettier.md
@@ -1,6 +1,6 @@
 # Automatic Code Formatting with Prettier
 
-Clean code is vital for any project, especially in a team codebase, but having to think about formatting details detracts from our attention which is better spent on crafting useful code. We can delegate formatting to tool that automates the process of applying formatting rules consistently across a codebase.
+Clean code is vital for any project, especially in a team codebase, but having to think about formatting details detracts from our attention which is better spent on crafting useful code. We can delegate formatting to a tool that automates the process of applying formatting rules consistently across a codebase.
 
 One of the most popular JavaScript formatting tools is [Prettier](https://prettier.io/). Like ESLint, we include a configuration file in our codebase and we have to install [a plugin for VS Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode). When configured correctly, it frees us from having to think about formatting! Let's go ahead and set that up.
 


### PR DESCRIPTION
## Brief Summary of Proposed Changes
- Fixes grammar error in article usage ("to tool" → "a tool")
- Removes extraneous word in ESLint documentation ("we can to add" → "we can add")
- Standardizes capitalization of "ESLint" and "Git" throughout documentation
## Rationale for Proposed Changes
Minor changes that were suggested by Copilot review.
## Link to any Related Issues
- #9 
- #29 
## Confirm

- [x] All text follows the [GitHub Flavored Markdown Spec](https://github.github.com/gfm/) and is organized using the correct heading levels.
- [x] All new pictures or media include descriptive alt text.
- [x] Code blocks have been formatted and given the appropriate language label.
