### PR TITLE
fix: update Week 1 broken image links (fixes #78)

### DIFF
--- a/learns-app-content/week-01/assignment.md
+++ b/learns-app-content/week-01/assignment.md
@@ -1,5 +1,4 @@
-<!-- h1, h2 already used by CTD Learns -->
-<!-- draft exercise composition v1-->
+<!-- h1, h2 already used by CTD Learns -->---<!-- draft exercise composition v1-->
 ### Expected App Capabilities
 
 After completing this week's assignment, your app should:
@@ -29,8 +28,7 @@ After completing this week's assignment, your app should:
 
 You will end up with a project structure that looks similar to the following:
 
-![screen capture of the newly installed project directory](https://raw.githubusercontent.com/Code-the-Dream-School/react-curriculum-v4/refs/heads/main/learns-app-content/week-01/assets/project-directory.png)
-
+![screen capture of the newly installed project directory](./assets/project-directory.png)
 ### Instructions Part 3: Project Setup
 
 > [!note]


### PR DESCRIPTION
## Brief Summary of Proposed Changes

This PR fixes the broken image links in Week 1.
The previous image URLs were pointing to outdated raw.githubusercontent.com paths, which no longer exist.
I updated them to use the correct local asset paths inside `week-01/assets`, so the images now render properly.

## Rationale for Proposed Changes

The Week 1 images were not showing because the external URLs were invalid.
Since the image files already exist in the repository under `learns-app-content/week-01/assets`, updating the Markdown image paths resolves the issue with no need to move or re-upload assets.

## Link to any Related Issues

Fixes #78.

## Confirm
- [x] All text follows the GitHub Flavored Markdown Spec and is organized using the correct heading levels.
- [x] All new pictures or media include descriptive alt text.
- [x] Code blocks have been formatted and given the appropriate language label.
