### PR TITLE
Update TodoForm to handle form submission correctly

### DIFF
--- a/learns-app-content/lesson-04-hooks-events-handlers/assignment.md
+++ b/learns-app-content/lesson-04-hooks-events-handlers/assignment.md
@@ -96,7 +96,7 @@ function TodoForm({ onAddTodo }) {
 
 ```jsx
 return (
-  <form>
+  <form onSubmit={handleAddTodo}>
     <label htmlFor="todoTitle">Todo</label>
     <input
       ref={inputRef}
@@ -106,7 +106,7 @@ return (
       placeholder={'Todo text'}
       required
     />
-    <button type="submit" onClick={handleAddTodo}>
+    <button type="submit">
       Add Todo
     </button>
   </form>


### PR DESCRIPTION
This pull request makes a small but important improvement to the `TodoForm` component by ensuring that the `handleAddTodo` function is only triggered on form submission, rather than both on the form and button click. This prevents duplicate submissions and aligns with best practices for handling form events in React.

- Updates to event handling:
  * Adds the `onSubmit={handleAddTodo}` handler to the `<form>` element and removes the `onClick` handler from the submit `<button>`, ensuring that the todo is added only once when the form is submitted. [[1]](diffhunk://#diff-8ba314756ce6bf3f282fb0cce644ac9a12385aefbb408878e0ce1b7eca9ea998L99-R99) [[2]](diffhunk://#diff-8ba314756ce6bf3f282fb0cce644ac9a12385aefbb408878e0ce1b7eca9ea998L109-R109)